### PR TITLE
refactor(todo): Todoページを責務ごとにコンポーネント分割

### DIFF
--- a/src/app/todo/components/ClearCompleted.tsx
+++ b/src/app/todo/components/ClearCompleted.tsx
@@ -1,0 +1,20 @@
+import React from 'react'
+
+interface Props {
+  hasCompleted: boolean
+  onClear: () => void
+}
+
+export default function ClearCompleted({ hasCompleted, onClear }: Props) {
+  if (!hasCompleted) return null
+  return (
+    <div className="mt-6 text-center">
+      <button
+        onClick={onClear}
+        className="text-sm text-gray-500 hover:text-red-500 transition-colors"
+      >
+        完了済みタスクを削除
+      </button>
+    </div>
+  )
+}

--- a/src/app/todo/components/TodoInput.tsx
+++ b/src/app/todo/components/TodoInput.tsx
@@ -1,0 +1,34 @@
+'use client'
+
+import React from 'react'
+
+interface Props {
+  value: string
+  onChange: (v: string) => void
+  onSubmit: () => void
+}
+
+export default function TodoInput({ value, onChange, onSubmit }: Props) {
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') onSubmit()
+  }
+
+  return (
+    <div className="flex gap-2 mb-6">
+      <input
+        type="text"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        onKeyDown={handleKeyDown}
+        placeholder="新しいタスクを追加..."
+        className="flex-1 px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white"
+      />
+      <button
+        onClick={onSubmit}
+        className="px-6 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500 transition-colors"
+      >
+        追加
+      </button>
+    </div>
+  )
+}

--- a/src/app/todo/components/TodoItem.tsx
+++ b/src/app/todo/components/TodoItem.tsx
@@ -1,0 +1,42 @@
+import React from 'react'
+import { Todo } from '../types'
+
+interface Props {
+  todo: Todo
+  onToggle: (id: string) => void
+  onDelete: (id: string) => void
+}
+
+export default function TodoItem({ todo, onToggle, onDelete }: Props) {
+  return (
+    <div
+      className={`flex items-center gap-3 p-3 border rounded-lg transition-all duration-200 ${
+        todo.completed
+          ? 'bg-green-50 dark:bg-green-900/20 border-green-200 dark:border-green-700'
+          : 'bg-gray-50 dark:bg-gray-700 border-gray-200 dark:border-gray-600'
+      }`}
+    >
+      <input
+        type="checkbox"
+        checked={todo.completed}
+        onChange={() => onToggle(todo.id)}
+        className="w-5 h-5 text-blue-600 focus:ring-blue-500 rounded"
+      />
+      <span
+        className={`flex-1 ${
+          todo.completed
+            ? 'text-gray-500 line-through'
+            : 'text-gray-800 dark:text-white'
+        }`}
+      >
+        {todo.text}
+      </span>
+      <button
+        onClick={() => onDelete(todo.id)}
+        className="px-3 py-1 text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20 rounded transition-colors"
+      >
+        削除
+      </button>
+    </div>
+  )
+}

--- a/src/app/todo/components/TodoList.tsx
+++ b/src/app/todo/components/TodoList.tsx
@@ -1,0 +1,27 @@
+import React from 'react'
+import { Todo } from '../types'
+import TodoItem from './TodoItem'
+
+interface Props {
+  todos: Todo[]
+  onToggle: (id: string) => void
+  onDelete: (id: string) => void
+}
+
+export default function TodoList({ todos, onToggle, onDelete }: Props) {
+  if (todos.length === 0) {
+    return (
+      <div className="text-center text-gray-500 dark:text-gray-400 py-8">
+        タスクはまだありません。上のフォームから追加してください。
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-2">
+      {todos.map((todo) => (
+        <TodoItem key={todo.id} todo={todo} onToggle={onToggle} onDelete={onDelete} />
+      ))}
+    </div>
+  )
+}

--- a/src/app/todo/components/TodoStats.tsx
+++ b/src/app/todo/components/TodoStats.tsx
@@ -1,0 +1,15 @@
+import React from 'react'
+
+interface Props {
+  completed: number
+  total: number
+}
+
+export default function TodoStats({ completed, total }: Props) {
+  if (total === 0) return null
+  return (
+    <div className="mb-4 text-sm text-gray-600 dark:text-gray-400 text-center">
+      {total} 件中 {completed} 件完了
+    </div>
+  )
+}

--- a/src/app/todo/page.tsx
+++ b/src/app/todo/page.tsx
@@ -1,12 +1,11 @@
 'use client'
 
 import { useState } from 'react'
-
-interface Todo {
-  id: string
-  text: string
-  completed: boolean
-}
+import TodoInput from './components/TodoInput'
+import TodoStats from './components/TodoStats'
+import TodoList from './components/TodoList'
+import ClearCompleted from './components/ClearCompleted'
+import { Todo } from './types'
 
 export default function TodoPage() {
   const [todos, setTodos] = useState<Todo[]>([])
@@ -38,10 +37,8 @@ export default function TodoPage() {
     setTodos(todos.filter((todo) => todo.id !== id))
   }
 
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'Enter') {
-      addTodo()
-    }
+  const clearCompleted = () => {
+    setTodos(todos.filter(todo => !todo.completed))
   }
 
   const completedCount = todos.filter(todo => todo.completed).length
@@ -53,85 +50,14 @@ export default function TodoPage() {
         <h1 className="text-3xl font-bold text-center mb-8 text-gray-800 dark:text-white">
           Todo App
         </h1>
-        
-        {/* Add Todo Form */}
-        <div className="flex gap-2 mb-6">
-          <input
-            type="text"
-            value={inputText}
-            onChange={(e) => setInputText(e.target.value)}
-            onKeyDown={handleKeyDown}
-            placeholder="新しいタスクを追加..."
-            className="flex-1 px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white"
-          />
-          <button
-            onClick={addTodo}
-            className="px-6 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500 transition-colors"
-          >
-            追加
-          </button>
-        </div>
 
-        {/* Stats */}
-        {totalCount > 0 && (
-          <div className="mb-4 text-sm text-gray-600 dark:text-gray-400 text-center">
-            {totalCount} 件中 {completedCount} 件完了
-          </div>
-        )}
+        <TodoInput value={inputText} onChange={setInputText} onSubmit={addTodo} />
 
-        {/* Todo List */}
-        <div className="space-y-2">
-          {todos.length === 0 ? (
-            <div className="text-center text-gray-500 dark:text-gray-400 py-8">
-              タスクはまだありません。上のフォームから追加してください。
-            </div>
-          ) : (
-            todos.map((todo) => (
-              <div
-                key={todo.id}
-                className={`flex items-center gap-3 p-3 border rounded-lg transition-all duration-200 ${
-                  todo.completed
-                    ? 'bg-green-50 dark:bg-green-900/20 border-green-200 dark:border-green-700'
-                    : 'bg-gray-50 dark:bg-gray-700 border-gray-200 dark:border-gray-600'
-                }`}
-              >
-                <input
-                  type="checkbox"
-                  checked={todo.completed}
-                  onChange={() => toggleTodo(todo.id)}
-                  className="w-5 h-5 text-blue-600 focus:ring-blue-500 rounded"
-                />
-                <span
-                  className={`flex-1 ${
-                    todo.completed
-                      ? 'text-gray-500 line-through'
-                      : 'text-gray-800 dark:text-white'
-                  }`}
-                >
-                  {todo.text}
-                </span>
-                <button
-                  onClick={() => deleteTodo(todo.id)}
-                  className="px-3 py-1 text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20 rounded transition-colors"
-                >
-                  削除
-                </button>
-              </div>
-            ))
-          )}
-        </div>
+        <TodoStats completed={completedCount} total={totalCount} />
 
-        {/* Clear completed */}
-        {completedCount > 0 && (
-          <div className="mt-6 text-center">
-            <button
-              onClick={() => setTodos(todos.filter(todo => !todo.completed))}
-              className="text-sm text-gray-500 hover:text-red-500 transition-colors"
-            >
-              完了済みタスクを削除
-            </button>
-          </div>
-        )}
+        <TodoList todos={todos} onToggle={toggleTodo} onDelete={deleteTodo} />
+
+        <ClearCompleted hasCompleted={completedCount > 0} onClear={clearCompleted} />
       </div>
     </div>
   )

--- a/src/app/todo/types.ts
+++ b/src/app/todo/types.ts
@@ -1,0 +1,5 @@
+export interface Todo {
+  id: string
+  text: string
+  completed: boolean
+}


### PR DESCRIPTION
以下の通り、/src/app/todo/page.tsx を責務ごとに分割しました。\n\n- types: src/app/todo/types.ts へ Todo 型を抽出\n- components: \n  - TodoInput（入力フォーム）\n  - TodoStats（統計表示）\n  - TodoList（一覧）+ TodoItem（アイテム操作）\n  - ClearCompleted（完了一括削除）\n- page.tsx は状態管理とコンポーネントのオーケストレーションのみを担当\n\n動作/UIの変更はありません。\n\n検証: \n- npm run build にて型チェック/ESLint 含め成功\n\nレビュー観点: \n- 責務の切り分けが適切か\n- props/型の粒度\n- 命名/配置（src/app/todo/components 配下でよいか）